### PR TITLE
Added missing charger type and fix for adding second charger

### DIFF
--- a/custom_components/alfen_wallbox/config_flow.py
+++ b/custom_components/alfen_wallbox/config_flow.py
@@ -26,7 +26,7 @@ class FlowHandler(config_entries.ConfigFlow):
         """Register new entry."""
         # Check if ip already is registered
         for entry in self._async_current_entries():
-            if entry.data[KEY_IP] == host:
+            if entry.data[CONF_HOST] == host:
                 return self.async_abort(reason="already_configured")
 
         return self.async_create_entry(title=host, data={CONF_HOST: host, CONF_NAME: name, CONF_USERNAME: username, CONF_PASSWORD: password})

--- a/custom_components/alfen_wallbox/const.py
+++ b/custom_components/alfen_wallbox/const.py
@@ -18,6 +18,7 @@ ALFEN_PRODUCT_MAP = {
     'NG900-60503': 'Eve Single S-line, 1 phase, LED, type 2 socket',
     'NG900-60505': 'Eve Single S-line, 1 phase, LED, type 2 shutter',
     'NG900-60507': 'Eve Single S-line, 1 phase, LED, charging cable',
+    'NG910-60587': 'Eve Single S-line, 3 phase, LED, charging cable',
     'NG910-60003': 'Eve Single Pro-line, 1 phase, display, type 2 socket',
     'NG910-60005': 'Eve Single Pro-line, 1 phase, display, type 2 shutter',
     'NG910-60007': 'Eve Single Pro-line, 1 phase, display, charging cable',

--- a/custom_components/alfen_wallbox/sensor.py
+++ b/custom_components/alfen_wallbox/sensor.py
@@ -135,6 +135,7 @@ class AlfenMainSensor(Entity):
             17: "Session end", #(Unit with socket only?) Cable still connected to EVSE after charging, but car disconnected. Screen shows charging stats until cable disconnected from EVSE.
             34: "Blocked", #EVSE is blocked through management interface of CPO.
             36: "Paused",
+            41: "Solar charging",
         }
         return switcher.get(self._device.status.status, "Unknown")
 


### PR DESCRIPTION
Product type NG910-60587 was missing.

Checking for existing integration was not working because of an invalid key from the object.

Fixes #8 