### PR TITLE
Added Generic Alfen Wallbox to product map

### DIFF
--- a/custom_components/alfen_wallbox/const.py
+++ b/custom_components/alfen_wallbox/const.py
@@ -19,6 +19,7 @@ ALFEN_PRODUCT_MAP = {
     'NG900-60505': 'Eve Single S-line, 1 phase, LED, type 2 shutter',
     'NG900-60507': 'Eve Single S-line, 1 phase, LED, charging cable',
     'NG910-60587': 'Eve Single S-line, 3 phase, LED, charging cable',
+    'Generic Alfen Wallbox': 'Eve Single S-line, 3 phase, LED, charging cable',
     'NG910-60583': 'Eve Single Pro-line, 3 phase, LED, type 2 socket',
     'NG910-60003': 'Eve Single Pro-line, 1 phase, display, type 2 socket',
     'NG910-60005': 'Eve Single Pro-line, 1 phase, display, type 2 shutter',

--- a/custom_components/alfen_wallbox/const.py
+++ b/custom_components/alfen_wallbox/const.py
@@ -19,7 +19,6 @@ ALFEN_PRODUCT_MAP = {
     'NG900-60505': 'Eve Single S-line, 1 phase, LED, type 2 shutter',
     'NG900-60507': 'Eve Single S-line, 1 phase, LED, charging cable',
     'NG910-60587': 'Eve Single S-line, 3 phase, LED, charging cable',
-    'Generic Alfen Wallbox': 'Eve Single S-line, 3 phase, LED, charging cable',
     'NG910-60583': 'Eve Single Pro-line, 3 phase, LED, type 2 socket',
     'NG910-60003': 'Eve Single Pro-line, 1 phase, display, type 2 socket',
     'NG910-60005': 'Eve Single Pro-line, 1 phase, display, type 2 shutter',
@@ -32,4 +31,6 @@ ALFEN_PRODUCT_MAP = {
     'NG920-61032': 'Eve Double Pro-line, 2 x type 2 socket, 2 phase, max. 1x32A input current',
     'NG920-61021': 'Eve Double Pro-line, 2 x type 2 socket, 3 phase, max. 1x32A input current',
     'NG920-61022': 'Eve Double Pro-line, 2 x type 2 socket, 3 phase, max. 2x32A input current',
+
+    'Generic Alfen Wallbox': 'Generic Alfen Wallbox',
 }


### PR DESCRIPTION
My Eve Single S-line, 3 phase, LED, charging cable reports itself as Generic Alfen Wallbox causing the same issue as reported [here](https://community.home-assistant.io/t/alfen-eve-pro-ev-chargepoint-interface-via-tcp-modbus/346000/111)