### PR TITLE
Add status code 26 to sensor.py

### DIFF
--- a/custom_components/alfen_wallbox/sensor.py
+++ b/custom_components/alfen_wallbox/sensor.py
@@ -133,6 +133,7 @@ class AlfenMainSensor(Entity):
             10: "Vehicle connected",
             11: "Charging",
             17: "Session end", #(Unit with socket only?) Cable still connected to EVSE after charging, but car disconnected. Screen shows charging stats until cable disconnected from EVSE.
+            26: "ConnectorLock Failure", #Not able to lock cable.Please reconnect cable
             34: "Blocked", #EVSE is blocked through management interface of CPO.
             36: "Paused",
             41: "Solar charging",


### PR DESCRIPTION
status code 26 isn't translated.
It happens when the lock is unable to lock the charging cable, used with a socket
I took same naming as for Error 404 from the doc :
https://alfen.com/file-download/download/public/1611