### PR TITLE
add missing await Update alfen.py

### DIFF
--- a/custom_components/alfen_wallbox/alfen.py
+++ b/custom_components/alfen_wallbox/alfen.py
@@ -81,7 +81,7 @@ class AlfenDevice:
         )
 
         _LOGGER.debug(f"Status Response {response}")
-        self._session.request(
+        await self._session.request(
             ssl=self.ssl,
             method="POST",
             headers=HEADER_JSON,


### PR DESCRIPTION
Log from HA:
 WARNING (MainThread) [py.warnings] /config/custom_components/alfen_wallbox/alfen.py:84: RuntimeWarning: coroutine 'ClientSession._request' was never awaited
  self._session.request(